### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ for ($i = 0; $i < 100000; $i++) {
 		"description" => "description" . $i,
 	));
 }
-$this->database->commit();
+$multiInsert->save();
 ```
 
 4) Using Helbrary\DbPerformance\MultiInsert with buffer size 500: **0 min 14 sec**


### PR DESCRIPTION
Fix typo in documentation - use `$multiInsert->save` instead of `$this->database->commit()", since this would throw an error ("No transaction to commit").
