### PR TITLE
Fix #4: Exception on saving when buffer is empty

### DIFF
--- a/src/MultiInsert.php
+++ b/src/MultiInsert.php
@@ -36,6 +36,10 @@ class MultiInsert extends Multi
 	public function save()
 	{
 		try {
+			// Do not try to save on an empty buffer
+			if (count($this->buffer) == 0) {
+				return;
+			}
 			$this->database->beginTransaction();
 			$this->database->table($this->table)->insert($this->buffer);
 			$this->database->commit();
@@ -51,6 +55,10 @@ class MultiInsert extends Multi
 	 */
 	private function saveIndividually()
 	{
+		// Do not try to save on an empty buffer
+		if (count($this->buffer) == 0) {
+			return;
+		}
 		$this->database->beginTransaction();
 		foreach ($this->buffer as $itemData) {
 			try {

--- a/src/MultiUpdate.php
+++ b/src/MultiUpdate.php
@@ -56,6 +56,10 @@ class MultiUpdate extends Multi
 	public function save()
 	{
 		try {
+			// Do not try to update on an empty buffer
+			if (count($this->buffer) == 0) {
+				return;
+			}
 			$this->database->beginTransaction();
 			$this->database->queryArgs($this->buildMultiUpdate(), $this->getArgs());
 			$this->database->commit();
@@ -88,6 +92,10 @@ class MultiUpdate extends Multi
 	 */
 	private function saveIndividually()
 	{
+		// Do not try to save on an empty buffer
+		if (count($this->buffer) == 0) {
+			return;
+		}
 		$this->database->beginTransaction();
 		foreach ($this->buffer as $id => $value) {
 			try {


### PR DESCRIPTION
Added empty buffer checks to 'save' and 'saveIndividually' methods of both 'MultiInsert' and 'MultiUpdate'
